### PR TITLE
Default rmw implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,6 @@ endforeach()
 
 target_link_libraries(turtlesim_node 
   ${QT_LIBRARIES}
-  ${rclcpp_LIBRARIES}
 )
 ament_target_dependencies(turtlesim_node
   "rclcpp"
@@ -80,9 +79,6 @@ foreach(rmw_implementation ${rmw_implementations2})
   endforeach()
 endforeach()
 
-target_link_libraries(turtle_teleop_key 
-  ${rclcpp_LIBRARIES}
-)
 ament_target_dependencies(turtle_teleop_key
   "rclcpp"
   "geometry_msgs"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,14 +69,10 @@ add_executable(turtle_teleop_key
   tutorials/teleop_turtle_key.cpp
 )
 
-foreach(rmw_implementation ${rmw_implementations2})
-  find_package("${rmw_implementation}" REQUIRED)
-  get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
-  foreach(typesupport_impl ${typesupport_impls})
-    rosidl_target_interfaces(turtle_teleop_key
-      ${PROJECT_NAME} ${typesupport_impl}
-    )
-  endforeach()
+foreach(typesupport_impl ${typesupport_impls})
+  rosidl_target_interfaces(turtle_teleop_key
+    ${PROJECT_NAME} ${typesupport_impl}
+  )
 endforeach()
 
 ament_target_dependencies(turtle_teleop_key

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,15 +46,13 @@ add_executable(turtlesim_node
   ${turtlesim_node_MOCS}
 )
 
-get_available_rmw_implementations(rmw_implementations2)
-foreach(rmw_implementation ${rmw_implementations2})
-  find_package("${rmw_implementation}" REQUIRED)
-  get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
-  foreach(typesupport_impl ${typesupport_impls})
-    rosidl_target_interfaces(turtlesim_node
-      ${PROJECT_NAME} ${typesupport_impl}
-    )
-  endforeach()
+get_default_rmw_implementation(rmw_implementation)
+find_package("${rmw_implementation}" REQUIRED)
+get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
+foreach(typesupport_impl ${typesupport_impls})
+  rosidl_target_interfaces(turtlesim_node
+    ${PROJECT_NAME} ${typesupport_impl}
+  )
 endforeach()
 
 target_link_libraries(turtlesim_node 


### PR DESCRIPTION
I don't know if this is of any value to you, I noticed that your code was only linking against the default rmw_implementation. If this is the intended behaviour, this PR allows you to reduce the amount of CMake boilerplate in the case of using only the default rmw_implementation.

Note: I don't have Qt4 on my machine so you may want to test this PR before considering merging it.